### PR TITLE
add bidrectional functionality

### DIFF
--- a/contracts/RedeemNFT.sol
+++ b/contracts/RedeemNFT.sol
@@ -1,9 +1,12 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC1155/ERC1155.sol";
+import "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Receiver.sol";
 import "hardhat/console.sol";
 
 interface IERC20 {
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
     function allowance(address owner, address spender) external view returns (uint256);
     function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
     function permit(
@@ -27,7 +30,7 @@ contract ERC1155Mint is ERC1155 {
   }
 }
 
-contract RedeemNFT {
+contract RedeemNFT is ERC1155Receiver {
   IERC20 public immutable token;
   ERC1155 public immutable nft;
 
@@ -37,11 +40,10 @@ contract RedeemNFT {
     nft = new ERC1155Mint(address(this), _uri);
   }
 
-  function redeemERC20ForNFT(address redeemer) public {
+  function redeemERC20ForNFT(address redeemer) internal {
     uint256 balance = token.allowance(redeemer, address(this)) / 10**18;
     require(balance > 0, "Balance of redemption token less than 1");
     token.transferFrom(redeemer, address(this), balance * 10**18);
-    uint256 nftbalance = nft.balanceOf(address(this), 0);
     nft.safeTransferFrom(address(this), redeemer, 0, balance, "");
   }
 
@@ -56,5 +58,31 @@ contract RedeemNFT {
     ) external {
       token.permit(owner, spender, value, deadline, v, r, s);
       redeemERC20ForNFT(owner);
-    }
+  }
+
+  function redeemNFTForERC20() external {
+    uint256 nftBalance = nft.balanceOf(msg.sender, 0);
+    nft.safeTransferFrom(msg.sender, address(this), 0, nftBalance, "");
+    token.transfer(msg.sender, nftBalance * 10**18);
+  }
+
+  function onERC1155Received(
+        address operator,
+        address from,
+        uint256 id,
+        uint256 value,
+        bytes calldata data
+    ) override external pure returns (bytes4){
+      return bytes4(keccak256("onERC1155Received(address,address,uint256,uint256,bytes)"));
+  }
+
+  function onERC1155BatchReceived(
+      address operator,
+      address from,
+      uint256[] calldata ids,
+      uint256[] calldata values,
+      bytes calldata data
+  ) override external returns (bytes4){
+
+  }
 }


### PR DESCRIPTION
This resolves issue #1 that allows the user to redeem an ERC20 for an ERC1155 and an ERC1155 for an ERC20